### PR TITLE
feat: Add CD playback to UIX-Desktop

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -482,6 +482,19 @@ MPV_CFLAGS   =
 MPV_LDFLAGS  =
 MPV_DEFINES  =
 
+# CD Audio playback (libmpv, audio-only - no OpenGL render context).
+# Enabled automatically when pkg-config finds libmpv.
+# Disc detection and TOC reading work regardless (platform ioctls only).
+ifeq ($(shell pkg-config --exists mpv 2>/dev/null && echo yes),yes)
+  CDAUDIO_CFLAGS  := $(shell pkg-config --cflags mpv)
+  CDAUDIO_LDFLAGS := $(shell pkg-config --libs mpv)
+  CDAUDIO_DEFINES := -DUIX_CDAUDIO=1
+else
+  CDAUDIO_CFLAGS  :=
+  CDAUDIO_LDFLAGS :=
+  CDAUDIO_DEFINES :=
+endif
+
 DESKTOP_CFLAGS = \
 	-std=c++17 \
 	$(if $(DEBUG),-g -O0,-O2 -DNDEBUG) \
@@ -518,9 +531,11 @@ DESKTOP_CFLAGS = \
 	-Wno-null-conversion \
 	-Wno-c++11-narrowing \
 	$(MPV_DEFINES) \
-	$(MPV_CFLAGS)
+	$(MPV_CFLAGS) \
+	$(CDAUDIO_DEFINES) \
+	$(CDAUDIO_CFLAGS)
 
-DESKTOP_LDFLAGS = $(SDL2_LDFLAGS) $(DESKTOP_PLATFORM_LDFLAGS) $(MPV_LDFLAGS) -lm
+DESKTOP_LDFLAGS = $(SDL2_LDFLAGS) $(DESKTOP_PLATFORM_LDFLAGS) $(MPV_LDFLAGS) $(CDAUDIO_LDFLAGS) -lm
 
 # Toggle: build the desktop with AddressSanitizer to catch UB / UAF
 # at runtime. Use: `make desktop ASAN=1`.
@@ -591,6 +606,7 @@ DESKTOP_SRCS_PLATFORM = \
 	$(THESEUS_SRC)/desktop/desktop_stubs.cpp \
 	$(THESEUS_SRC)/desktop/desktop_nodes.cpp \
 	$(THESEUS_SRC)/desktop/audio_sdl.cpp \
+	$(THESEUS_SRC)/desktop/cdaudio.cpp \
 	$(THESEUS_SRC)/desktop/inspector.cpp \
 	$(THESEUS_SRC)/desktop/menu_bar.cpp \
 	$(THESEUS_SRC)/desktop/xap_editor.cpp \
@@ -673,11 +689,14 @@ WIN64_DIR     = $(BUILDS_ROOT)/desktop-win64
 WIN64_TARGET  = $(WIN64_DIR)/theseus.exe
 WIN64_CXX     = x86_64-w64-mingw32-g++
 
-# libwinpthread-1.dll lives in the toolchain's x86_64-w64-mingw32/bin dir,
-# next to the real (un-symlinked) compiler. Use realpath so this still
-# points at the right brew Cellar after upgrades, instead of following
-# /opt/homebrew/bin/ which is a symlink layer that doesn't have the DLL.
-WIN64_PTHREAD_DLL := $(shell dirname $$(dirname $$(realpath $$(which x86_64-w64-mingw32-gcc 2>/dev/null))))/x86_64-w64-mingw32/bin/libwinpthread-1.dll
+# libwinpthread-1.dll: on macOS/Homebrew it lives in x86_64-w64-mingw32/bin/;
+# on Linux/APT it lives in x86_64-w64-mingw32/lib/. Try bin/ first, fall back
+# to lib/ so both layouts work without manual configuration.
+WIN64_PTHREAD_DLL := $(shell \
+  BASE=$$(dirname $$(dirname $$(realpath $$(which x86_64-w64-mingw32-gcc 2>/dev/null)))) ; \
+  BIN=$$BASE/x86_64-w64-mingw32/bin/libwinpthread-1.dll ; \
+  LIB=$$BASE/x86_64-w64-mingw32/lib/libwinpthread-1.dll ; \
+  if [ -f "$$BIN" ]; then echo $$BIN ; elif [ -f "$$LIB" ]; then echo $$LIB ; fi)
 
 SDL2_MINGW_DIR    ?= $(HOME)/cross/sdl2-mingw
 SDL2_MINGW_INC    = $(SDL2_MINGW_DIR)/SDL2-2.32.10/x86_64-w64-mingw32/include

--- a/theseus/desktop/cdaudio.cpp
+++ b/theseus/desktop/cdaudio.cpp
@@ -1,0 +1,529 @@
+// cdaudio.cpp: Audio CD detection, TOC reading, and playback.
+//
+// TOC detection: platform ioctls, no extra deps.
+//   Linux  : <linux/cdrom.h>  CDROMREADTOCHDR / CDROMREADTOCENTRY
+//   Windows: <ntddcdrm.h>     DeviceIoControl  IOCTL_CDROM_READ_TOC
+//
+// Playback backends (first match wins):
+//   UIX_CDAUDIO           : libmpv audio-only handle
+//   Linux or Windows      : CDROMREADAUDIO / IOCTL_CDROM_RAW_READ + SDL audio
+//   Anything else         : stubs (detection still works)
+//
+// The SDL ring-buffer backend is shared between Linux and Windows;
+// only the reader-thread ioctl differs.
+
+#include "cdaudio.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#define MAX_CDTRACKS 99
+
+// ============================================================================
+// Platform: disc detection + TOC + track LBAs
+// ============================================================================
+
+#if defined(__linux__)
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/cdrom.h>
+
+static const char* s_devCandidates[] = {
+    "/dev/cdrom", "/dev/sr0", "/dev/sr1", "/dev/dvd", nullptr
+};
+static int s_trackStartLBA[MAX_CDTRACKS] = {};
+static int s_leadOutLBA = 0;
+
+static int OpenDevice()
+{
+    for (const char** d = s_devCandidates; *d; ++d) {
+        int fd = open(*d, O_RDONLY | O_NONBLOCK);
+        if (fd >= 0) return fd;
+    }
+    return -1;
+}
+
+static CdDiscType PlatformReadTOC(int* outCount, int* outDurations, int maxTracks)
+{
+    if (outCount) *outCount = 0;
+    int fd = OpenDevice();
+    if (fd < 0) return CD_NONE;
+
+    if (ioctl(fd, CDROM_DRIVE_STATUS, CDSL_CURRENT) != CDS_DISC_OK) { close(fd); return CD_NONE; }
+
+    struct cdrom_tochdr hdr;
+    if (ioctl(fd, CDROMREADTOCHDR, &hdr) < 0) { close(fd); return CD_NONE; }
+
+    int first = hdr.cdth_trk0, last = hdr.cdth_trk1;
+    if (outCount) *outCount = last - first + 1;
+
+    bool allAudio = true;
+    int  prevSec  = 0;
+    bool gotPrev  = false;
+
+    for (int t = first; t <= last + 1; ++t) {
+        struct cdrom_tocentry e;
+        memset(&e, 0, sizeof(e));
+        e.cdte_track  = (t <= last) ? t : CDROM_LEADOUT;
+        e.cdte_format = CDROM_MSF;
+        if (ioctl(fd, CDROMREADTOCENTRY, &e) < 0) break;
+
+        int sec = e.cdte_addr.msf.minute * 60 + e.cdte_addr.msf.second;
+        int lba = ((int)e.cdte_addr.msf.minute * 60 + e.cdte_addr.msf.second) * 75
+                  + e.cdte_addr.msf.frame - 150;
+        if (lba < 0) lba = 0;
+
+        if (gotPrev && outDurations) {
+            int idx = (t - 1) - first;
+            if (idx >= 0 && idx < maxTracks)
+                outDurations[idx] = (sec > prevSec) ? (sec - prevSec) : 0;
+        }
+        if (t <= last) {
+            if (e.cdte_ctrl & CDROM_DATA_TRACK) allAudio = false;
+            s_trackStartLBA[t - first] = lba;
+        } else {
+            s_leadOutLBA = lba;
+        }
+        prevSec = sec;
+        gotPrev = true;
+    }
+    close(fd);
+    return allAudio ? CD_AUDIO : CD_DATA;
+}
+
+static void PlatformPopulatePlaybackInfo() {}  // already done in PlatformReadTOC
+
+#elif defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winioctl.h>
+#include <ntddcdrm.h>
+
+// RAW_READ_INFO / IOCTL_CDROM_RAW_READ: defined locally so we don't depend
+// on mingw-w64 version shipping them.
+struct CdRawReadInfo {
+    LARGE_INTEGER DiskOffset;   // LBA * 2048
+    ULONG         SectorCount;
+    ULONG         TrackMode;    // 2 = CDDA
+};
+#ifndef IOCTL_CDROM_RAW_READ
+// CTL_CODE(0x2, 0xF, METHOD_OUT_DIRECT=2, FILE_READ_ACCESS=1)
+#define IOCTL_CDROM_RAW_READ 0x0002403E
+#endif
+
+static char s_cdDriveLetter         = 0;
+static int  s_trackStartLBA[MAX_CDTRACKS] = {};
+static int  s_leadOutLBA            = 0;
+
+static HANDLE OpenCdromDevice()
+{
+    char path[] = "\\\\.\\D:";
+    for (char c = 'D'; c <= 'H'; ++c) {
+        char root[4] = { c, ':', '\\', 0 };
+        if (GetDriveTypeA(root) != DRIVE_CDROM) continue;
+        path[4] = c;
+        HANDLE h = CreateFileA(path, GENERIC_READ,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE,
+                               nullptr, OPEN_EXISTING, 0, nullptr);
+        if (h != INVALID_HANDLE_VALUE) {
+            s_cdDriveLetter = c;
+            return h;
+        }
+    }
+    return INVALID_HANDLE_VALUE;
+}
+
+static CdDiscType PlatformReadTOC(int* outCount, int* outDurations, int maxTracks)
+{
+    if (outCount) *outCount = 0;
+    HANDLE h = OpenCdromDevice();
+    if (h == INVALID_HANDLE_VALUE) return CD_NONE;
+
+    CDROM_TOC toc;
+    DWORD br = 0;
+    BOOL ok = DeviceIoControl(h, IOCTL_CDROM_READ_TOC,
+                               nullptr, 0, &toc, sizeof(toc), &br, nullptr);
+    CloseHandle(h);
+    if (!ok) return CD_NONE;
+
+    int count = toc.LastTrack - toc.FirstTrack + 1;
+    if (outCount) *outCount = count;
+
+    bool allAudio = true;
+    for (int i = 0; i <= count; ++i) {  // +1 to include lead-out
+        int ti = toc.FirstTrack - 1 + i;  // index into TrackData
+        UCHAR* a = toc.TrackData[ti].Address;
+        int lba = ((int)a[1] * 60 + a[2]) * 75 + a[3] - 150;
+        if (lba < 0) lba = 0;
+
+        if (i < count) {
+            if (toc.TrackData[ti].Control & 4) allAudio = false;
+            s_trackStartLBA[i] = lba;
+            if (outDurations && i + 1 <= count) {
+                UCHAR* b = toc.TrackData[ti + 1].Address;
+                int t0 = (int)a[1] * 60 + a[2];
+                int t1 = (int)b[1] * 60 + b[2];
+                outDurations[i] = (t1 > t0) ? (t1 - t0) : 0;
+            }
+        } else {
+            s_leadOutLBA = lba;
+        }
+    }
+    return allAudio ? CD_AUDIO : CD_DATA;
+}
+
+static void PlatformPopulatePlaybackInfo() {}
+
+#else
+
+static CdDiscType PlatformReadTOC(int* outCount, int* outDurations, int maxTracks)
+{
+    if (outCount) *outCount = 0;
+    (void)outDurations; (void)maxTracks;
+    return CD_NONE;
+}
+static void PlatformPopulatePlaybackInfo() {}
+
+#endif  // platform
+
+// ============================================================================
+// Shared state — populated by CdAudio_Poll()
+// ============================================================================
+
+static CdDiscType s_discType   = CD_NONE;
+static int        s_trackCount = 0;
+static int        s_trackDurations[MAX_CDTRACKS] = {};
+static int        s_totalSeconds = 0;
+
+// ============================================================================
+// Playback backends
+// ============================================================================
+
+// ---- A: libmpv (cross-platform audio-only) ---------------------------------
+#ifdef UIX_CDAUDIO
+
+#include <mpv/client.h>
+
+static mpv_handle* s_mpv            = nullptr;
+static bool        s_playing        = false;
+static bool        s_paused         = false;
+static int         s_pendingChapter = -1;
+static double      s_timePos        = 0.0;
+static double      s_chapterStart   = 0.0;
+
+static void CdBack_Init()
+{
+    s_mpv = mpv_create();
+    if (!s_mpv) { fprintf(stderr, "[CdAudio] mpv_create failed\n"); return; }
+    mpv_set_option_string(s_mpv, "video",         "no");
+    mpv_set_option_string(s_mpv, "audio-display", "no");
+    mpv_set_option_string(s_mpv, "keep-open",     "yes");
+    mpv_set_option_string(s_mpv, "terminal",      "no");
+    if (mpv_initialize(s_mpv) < 0) {
+        fprintf(stderr, "[CdAudio] mpv_initialize failed\n");
+        mpv_destroy(s_mpv); s_mpv = nullptr; return;
+    }
+    mpv_observe_property(s_mpv, 0, "time-pos", MPV_FORMAT_DOUBLE);
+}
+
+static void CdBack_Shutdown() { if (s_mpv) { mpv_destroy(s_mpv); s_mpv = nullptr; } }
+
+bool CdAudio_Play(int track)
+{
+    if (!s_mpv || track < 1) return false;
+    s_pendingChapter = track - 1;
+    s_playing = true; s_paused = false; s_timePos = 0.0; s_chapterStart = 0.0;
+    for (int i = 0; i < track - 1 && i < s_trackCount; ++i) s_chapterStart += s_trackDurations[i];
+    const char* cmd[] = { "loadfile", "cdda://", "replace", nullptr };
+    if (mpv_command(s_mpv, cmd) < 0) { s_playing = false; return false; }
+    return true;
+}
+void CdAudio_Stop()   { if (s_mpv) { const char* c[] = {"stop",nullptr}; mpv_command(s_mpv,c); } s_playing=s_paused=false; }
+void CdAudio_Pause()  { if (s_mpv&&s_playing){ mpv_set_property_string(s_mpv,"pause","yes"); s_paused=true; } }
+void CdAudio_Resume() { if (s_mpv){ mpv_set_property_string(s_mpv,"pause","no"); s_paused=false; } }
+bool   CdAudio_IsPlaying()   { return s_playing && !s_paused; }
+bool   CdAudio_IsPaused()    { return s_playing && s_paused; }
+double CdAudio_GetPosition() { double p=s_timePos-s_chapterStart; return p<0.0?0.0:p; }
+void CdAudio_Update()
+{
+    if (!s_mpv) return;
+    for (mpv_event* e; (e=mpv_wait_event(s_mpv,0))->event_id!=MPV_EVENT_NONE;) {
+        if (e->event_id==MPV_EVENT_FILE_LOADED && s_pendingChapter>=0) {
+            int64_t ch=s_pendingChapter; mpv_set_property(s_mpv,"chapter",MPV_FORMAT_INT64,&ch); s_pendingChapter=-1;
+        } else if (e->event_id==MPV_EVENT_END_FILE) {
+            s_playing=s_paused=false;
+        } else if (e->event_id==MPV_EVENT_PROPERTY_CHANGE) {
+            auto* p=(mpv_event_property*)e->data;
+            if (!strcmp(p->name,"time-pos")&&p->format==MPV_FORMAT_DOUBLE) s_timePos=*(double*)p->data;
+        }
+    }
+}
+
+// ---- B: SDL ring-buffer + platform raw-sector read (Linux + Windows) -------
+#elif defined(__linux__) || defined(_WIN32)
+
+#include <SDL.h>
+
+#define CDDA_FRAME_BYTES  2352
+#define CDDA_RING_FRAMES  300
+#define CDDA_RING_BYTES   (CDDA_RING_FRAMES * CDDA_FRAME_BYTES)
+#define CDDA_READ_BATCH   25
+
+static uint8_t s_ring[CDDA_RING_BYTES];
+static int     s_ringRead = 0, s_ringWrite = 0, s_ringFill = 0;
+
+static SDL_mutex*        s_mutex  = nullptr;
+static SDL_cond*         s_cond   = nullptr;
+static SDL_AudioDeviceID s_dev    = 0;
+static SDL_Thread*       s_thread = nullptr;
+
+static SDL_atomic_t s_atomPlaying   = {0};
+static SDL_atomic_t s_atomPaused    = {0};
+static SDL_atomic_t s_atomStop      = {0};
+static SDL_atomic_t s_bytesConsumed = {0};
+
+static void SDLCALL AudioCb(void*, uint8_t* stream, int len)
+{
+    SDL_LockMutex(s_mutex);
+    int fill = len <= s_ringFill ? len : s_ringFill;
+    for (int i = 0; i < fill; i++) {
+        stream[i] = s_ring[s_ringRead];
+        s_ringRead = (s_ringRead + 1) % CDDA_RING_BYTES;
+    }
+    if (fill < len) memset(stream + fill, 0, len - fill);
+    s_ringFill -= fill;
+    SDL_CondSignal(s_cond);
+    SDL_UnlockMutex(s_mutex);
+    SDL_AtomicAdd(&s_bytesConsumed, fill);
+}
+
+struct ReaderArgs { int startLBA, endLBA; };
+
+static int SDLCALL ReaderFunc(void* arg)
+{
+    ReaderArgs ra = *(ReaderArgs*)arg;
+    free(arg);
+
+    uint8_t buf[CDDA_READ_BATCH * CDDA_FRAME_BYTES];
+    int lba = ra.startLBA;
+    bool readOk = true;
+
+// ----- platform-specific device open + read -----
+#if defined(__linux__)
+    int fd = OpenDevice();
+    if (fd < 0) {
+        fprintf(stderr, "[CdAudio] cannot open device\n");
+        SDL_AtomicSet(&s_atomPlaying, 0);
+        return -1;
+    }
+
+    while (!SDL_AtomicGet(&s_atomStop) && lba < ra.endLBA) {
+        if (SDL_AtomicGet(&s_atomPaused)) { SDL_Delay(20); continue; }
+        int n = CDDA_READ_BATCH;
+        if (lba + n > ra.endLBA) n = ra.endLBA - lba;
+
+        struct cdrom_read_audio rda;
+        memset(&rda, 0, sizeof(rda));
+        rda.addr.lba = lba; rda.addr_format = CDROM_LBA;
+        rda.nframes  = n;   rda.buf          = buf;
+
+        if (ioctl(fd, CDROMREADAUDIO, &rda) < 0) {
+            fprintf(stderr, "[CdAudio] CDROMREADAUDIO at LBA %d: %s\n", lba, strerror(errno));
+            readOk = false; break;
+        }
+
+        int bytes = n * CDDA_FRAME_BYTES;
+        SDL_LockMutex(s_mutex);
+        while (!SDL_AtomicGet(&s_atomStop) && (CDDA_RING_BYTES - s_ringFill) < bytes)
+            SDL_CondWait(s_cond, s_mutex);
+        if (!SDL_AtomicGet(&s_atomStop)) {
+            for (int i = 0; i < bytes; i++) { s_ring[s_ringWrite]=buf[i]; s_ringWrite=(s_ringWrite+1)%CDDA_RING_BYTES; }
+            s_ringFill += bytes;
+        }
+        SDL_UnlockMutex(s_mutex);
+        lba += n;
+    }
+    close(fd);
+
+#elif defined(_WIN32)
+    char devPath[16];
+    snprintf(devPath, sizeof(devPath), "\\\\.\\%c:", s_cdDriveLetter ? s_cdDriveLetter : 'D');
+    HANDLE hDev = CreateFileA(devPath, GENERIC_READ,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr, OPEN_EXISTING, 0, nullptr);
+    if (hDev == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[CdAudio] cannot open %s: error %lu\n", devPath, GetLastError());
+        SDL_AtomicSet(&s_atomPlaying, 0);
+        return -1;
+    }
+
+    while (!SDL_AtomicGet(&s_atomStop) && lba < ra.endLBA) {
+        if (SDL_AtomicGet(&s_atomPaused)) { SDL_Delay(20); continue; }
+        int n = CDDA_READ_BATCH;
+        if (lba + n > ra.endLBA) n = ra.endLBA - lba;
+
+        CdRawReadInfo rri;
+        rri.DiskOffset.QuadPart = (LONGLONG)lba * 2048;
+        rri.SectorCount = n;
+        rri.TrackMode   = 2;  // CDDA
+
+        DWORD br = 0;
+        if (!DeviceIoControl(hDev, IOCTL_CDROM_RAW_READ,
+                              &rri, sizeof(rri), buf, n * CDDA_FRAME_BYTES, &br, nullptr)) {
+            fprintf(stderr, "[CdAudio] IOCTL_CDROM_RAW_READ at LBA %d: error %lu\n", lba, GetLastError());
+            readOk = false; break;
+        }
+
+        int bytes = n * CDDA_FRAME_BYTES;
+        SDL_LockMutex(s_mutex);
+        while (!SDL_AtomicGet(&s_atomStop) && (CDDA_RING_BYTES - s_ringFill) < bytes)
+            SDL_CondWait(s_cond, s_mutex);
+        if (!SDL_AtomicGet(&s_atomStop)) {
+            for (int i = 0; i < bytes; i++) { s_ring[s_ringWrite]=buf[i]; s_ringWrite=(s_ringWrite+1)%CDDA_RING_BYTES; }
+            s_ringFill += bytes;
+        }
+        SDL_UnlockMutex(s_mutex);
+        lba += n;
+    }
+    CloseHandle(hDev);
+#endif  // platform read
+// ------------------------------------------------
+
+    if (readOk) {
+        // Wait for ring to drain before marking end-of-track
+        SDL_LockMutex(s_mutex);
+        while (!SDL_AtomicGet(&s_atomStop) && s_ringFill > 0)
+            SDL_CondWait(s_cond, s_mutex);
+        SDL_UnlockMutex(s_mutex);
+    }
+
+    SDL_AtomicSet(&s_atomPlaying, 0);
+    return 0;
+}
+
+static void StopAndJoin()
+{
+    SDL_AtomicSet(&s_atomStop, 1);
+    if (s_dev) SDL_PauseAudioDevice(s_dev, 1);
+    if (s_mutex) { SDL_LockMutex(s_mutex); SDL_CondBroadcast(s_cond); SDL_UnlockMutex(s_mutex); }
+    if (s_thread) { SDL_WaitThread(s_thread, nullptr); s_thread = nullptr; }
+    SDL_AtomicSet(&s_atomPlaying, 0);
+    SDL_AtomicSet(&s_atomPaused,  0);
+    SDL_AtomicSet(&s_atomStop,    0);
+    if (s_mutex) { SDL_LockMutex(s_mutex); s_ringRead=s_ringWrite=s_ringFill=0; SDL_UnlockMutex(s_mutex); }
+}
+
+static void CdBack_Init()
+{
+    s_mutex = SDL_CreateMutex();
+    s_cond  = SDL_CreateCond();
+}
+
+static void CdBack_Shutdown()
+{
+    StopAndJoin();
+    if (s_dev)   { SDL_CloseAudioDevice(s_dev); s_dev = 0; }
+    if (s_cond)  { SDL_DestroyCond(s_cond);     s_cond = nullptr; }
+    if (s_mutex) { SDL_DestroyMutex(s_mutex);   s_mutex = nullptr; }
+}
+
+bool CdAudio_Play(int track)
+{
+    if (track < 1 || track > s_trackCount) return false;
+
+    StopAndJoin();
+
+    int startLBA = s_trackStartLBA[track - 1];
+    int endLBA   = (track < s_trackCount) ? s_trackStartLBA[track] : s_leadOutLBA;
+
+    if (endLBA <= startLBA) {
+        fprintf(stderr, "[CdAudio] bad LBA range track %d: %d..%d\n", track, startLBA, endLBA);
+        return false;
+    }
+
+    SDL_AtomicSet(&s_bytesConsumed, 0);
+
+    if (!s_dev) {
+        SDL_AudioSpec want = {}, got = {};
+        want.freq = 44100; want.format = AUDIO_S16LSB;
+        want.channels = 2; want.samples = 2048; want.callback = AudioCb;
+        s_dev = SDL_OpenAudioDevice(nullptr, 0, &want, &got, 0);
+        if (!s_dev) {
+            fprintf(stderr, "[CdAudio] SDL_OpenAudioDevice: %s\n", SDL_GetError());
+            return false;
+        }
+    }
+
+    SDL_AtomicSet(&s_atomPlaying, 1);
+
+    ReaderArgs* ra = (ReaderArgs*)malloc(sizeof(ReaderArgs));
+    ra->startLBA = startLBA; ra->endLBA = endLBA;
+    s_thread = SDL_CreateThread(ReaderFunc, "CdAudioReader", ra);
+    if (!s_thread) {
+        fprintf(stderr, "[CdAudio] SDL_CreateThread: %s\n", SDL_GetError());
+        SDL_AtomicSet(&s_atomPlaying, 0); free(ra); return false;
+    }
+
+    SDL_PauseAudioDevice(s_dev, 0);
+    fprintf(stderr, "[CdAudio] Playing track %d (LBA %d..%d)\n", track, startLBA, endLBA);
+    return true;
+}
+
+void   CdAudio_Stop()    { StopAndJoin(); }
+void   CdAudio_Pause()   { if (SDL_AtomicGet(&s_atomPlaying)) { SDL_AtomicSet(&s_atomPaused,1); if(s_dev) SDL_PauseAudioDevice(s_dev,1); } }
+void   CdAudio_Resume()  { if (SDL_AtomicGet(&s_atomPlaying)) { SDL_AtomicSet(&s_atomPaused,0); if(s_dev) SDL_PauseAudioDevice(s_dev,0); } }
+bool   CdAudio_IsPlaying()   { return SDL_AtomicGet(&s_atomPlaying) && !SDL_AtomicGet(&s_atomPaused); }
+bool   CdAudio_IsPaused()    { return SDL_AtomicGet(&s_atomPlaying) &&  SDL_AtomicGet(&s_atomPaused); }
+double CdAudio_GetPosition() { return SDL_AtomicGet(&s_atomPlaying) ? SDL_AtomicGet(&s_bytesConsumed)/(44100.0*4.0) : 0.0; }
+void   CdAudio_Update()      {}
+
+// ---- C: stubs --------------------------------------------------------------
+#else
+
+static void CdBack_Init()     {}
+static void CdBack_Shutdown() {}
+bool   CdAudio_Play(int)     { return false; }
+void   CdAudio_Stop()        {}
+void   CdAudio_Pause()       {}
+void   CdAudio_Resume()      {}
+bool   CdAudio_IsPlaying()   { return false; }
+bool   CdAudio_IsPaused()    { return false; }
+double CdAudio_GetPosition() { return 0.0; }
+void   CdAudio_Update()      {}
+
+#endif  // playback backend
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void CdAudio_Init()     { CdBack_Init(); }
+void CdAudio_Shutdown() { CdBack_Shutdown(); }
+
+void CdAudio_Poll()
+{
+    int durations[MAX_CDTRACKS] = {};
+    int count = 0;
+    CdDiscType type = PlatformReadTOC(&count, durations, MAX_CDTRACKS);
+
+    s_discType = type;
+    if (type == CD_AUDIO) {
+        s_trackCount = count;
+        int total = 0;
+        for (int i = 0; i < count; ++i) { s_trackDurations[i] = durations[i]; total += durations[i]; }
+        s_totalSeconds = total;
+        PlatformPopulatePlaybackInfo();
+    } else {
+        s_trackCount = s_totalSeconds = 0;
+        memset(s_trackDurations, 0, sizeof(s_trackDurations));
+    }
+}
+
+CdDiscType CdAudio_GetDiscType()                  { return s_discType; }
+int        CdAudio_GetTrackCount()                { return s_trackCount; }
+int        CdAudio_GetTotalDurationSeconds()      { return s_totalSeconds; }
+int        CdAudio_GetTrackDurationSeconds(int t) { return (t>=1&&t<=s_trackCount)?s_trackDurations[t-1]:0; }

--- a/theseus/desktop/cdaudio.h
+++ b/theseus/desktop/cdaudio.h
@@ -1,0 +1,34 @@
+// cdaudio.h: Audio CD detection and playback for desktop builds.
+// TOC reading uses platform ioctls (no extra deps). Playback uses a
+// dedicated audio-only libmpv instance (guarded by UIX_CDAUDIO).
+
+#pragma once
+
+enum CdDiscType { CD_NONE = 0, CD_AUDIO, CD_DATA };
+
+// Init/shutdown — call from DashAudio_Init / DashAudio_Shutdown
+void CdAudio_Init();
+void CdAudio_Shutdown();
+
+// Poll for disc changes. Call every few seconds (e.g. from CDiscDrive::Advance).
+// Re-reads the TOC and updates internal state.
+void CdAudio_Poll();
+
+// Disc info — valid after Poll()
+CdDiscType CdAudio_GetDiscType();
+int        CdAudio_GetTrackCount();
+int        CdAudio_GetTrackDurationSeconds(int track);  // 1-based
+int        CdAudio_GetTotalDurationSeconds();
+
+// Playback — requires UIX_CDAUDIO (libmpv). Stubs return false/0 otherwise.
+// track: 1-based CD track number
+bool   CdAudio_Play(int track);
+void   CdAudio_Stop();
+void   CdAudio_Pause();
+void   CdAudio_Resume();
+bool   CdAudio_IsPlaying();
+bool   CdAudio_IsPaused();
+double CdAudio_GetPosition();  // seconds into the current track
+
+// Process pending mpv events. Call from CAudioClip::Advance while a cd: URL is active.
+void CdAudio_Update();

--- a/theseus/desktop/dashapp.cpp
+++ b/theseus/desktop/dashapp.cpp
@@ -14,6 +14,7 @@
 #include "camera.h"
 #include "scene_groups.h"
 #include "audio_sdl.h"
+#include "cdaudio.h"
 #include "settingsfile.h"
 extern void PreloadSkinTextures();
 
@@ -141,6 +142,8 @@ HRESULT InitAudio()
 	// Desktop: SDL_mixer audio engine
 	if (DashAudio_Init() < 0)
 		return E_FAIL;
+
+	CdAudio_Init();
 
 	return S_OK;
 }
@@ -626,6 +629,7 @@ void CleanupApp()
 	Locale_Exit();
 	Text_Exit();
 
+	CdAudio_Shutdown();
 	DashAudio_Shutdown();
 
 	delete[] g_szAppDir;

--- a/theseus/desktop/desktop_nodes.cpp
+++ b/theseus/desktop/desktop_nodes.cpp
@@ -17,6 +17,7 @@
 #include "node.h"
 #include "runner.h"
 #include "audio_sdl.h"
+#include "cdaudio.h"
 
 // Helper: resolve XAP audio URL to local filesystem path
 // XAP urls look like "Audio/MainAudio/A Button Select.wav" (relative to Q:\)
@@ -56,12 +57,16 @@ public:
 	}
 
 	void Unload() {
+		if (m_loadedUrl && strncmp(m_loadedUrl, "cd:", 3) == 0)
+			CdAudio_Stop();
 		if (m_channel >= 0) { DashAudio_StopChannel(m_channel); m_channel = -1; }
 		if (m_soundHandle >= 0) { DashAudio_FreeSound(m_soundHandle); m_soundHandle = -1; }
 		if (m_isStreaming) { DashAudio_FreeMusic(); m_isStreaming = false; }
 		free(m_loadedUrl);
 		m_loadedUrl = NULL;
 	}
+
+	static bool IsCdUrl(const char* url) { return url && strncmp(url, "cd:", 3) == 0; }
 
 	DECLARE_NODE(CAudioClip, CTimeDepNode)
 	DECLARE_NODE_PROPS()
@@ -110,7 +115,7 @@ public:
 			return;
 		}
 
-		// Handle "cd:" URLs; disc tracks (no-op on desktop, no disc drive)
+		// Handle "cd:N" URLs — CDDA track; CdAudio_Play handles the actual load
 		if (strncmp(m_url, "cd:", 3) == 0) {
 			m_loadedUrl = strdup(m_url);
 			return;
@@ -133,6 +138,18 @@ public:
 	void Play()
 	{
 		LoadIfNeeded();
+
+		if (IsCdUrl(m_loadedUrl)) {
+			int track = atoi(m_loadedUrl + 3);
+			if (track < 1) track = 1;
+			if (CdAudio_Play(track)) {
+				m_transportMode = 1;
+				m_isActive = true;
+				CallFunction(this, _T("onPlay"));
+				CallFunction(this, _T("OnTransportModeChanged"));
+			}
+			return;
+		}
 
 		if (m_isStreaming) {
 			int loops = m_loop ? -1 : 0;
@@ -161,6 +178,16 @@ public:
 
 	void Stop()
 	{
+		if (IsCdUrl(m_loadedUrl)) {
+			CdAudio_Stop();
+			m_transportMode = 0;
+			m_isActive = false;
+			m_progress = 0.0f;
+			CallFunction(this, _T("onStop"));
+			CallFunction(this, _T("OnTransportModeChanged"));
+			return;
+		}
+
 		if (m_isStreaming) {
 			int fadeMs = (m_fade > 0.0f) ? (int)(m_fade * 1000.0f) : 0;
 			DashAudio_StopMusic(fadeMs);
@@ -181,6 +208,15 @@ public:
 	void Pause()
 	{
 		if (m_transportMode != 1) return;
+
+		if (IsCdUrl(m_loadedUrl)) {
+			CdAudio_Pause();
+			m_transportMode = 2;
+			CallFunction(this, _T("onPause"));
+			CallFunction(this, _T("OnTransportModeChanged"));
+			return;
+		}
+
 		if (m_isStreaming)
 			DashAudio_PauseMusic();
 		else if (m_channel >= 0)
@@ -192,6 +228,20 @@ public:
 
 	void PlayOrPause()
 	{
+		if (IsCdUrl(m_loadedUrl)) {
+			if (m_transportMode == 1) {
+				Pause();
+			} else if (m_transportMode == 2) {
+				CdAudio_Resume();
+				m_transportMode = 1;
+				CallFunction(this, _T("onPlay"));
+				CallFunction(this, _T("OnTransportModeChanged"));
+			} else {
+				Play();
+			}
+			return;
+		}
+
 		if (m_transportMode == 1)
 			Pause();
 		else if (m_transportMode == 2) {
@@ -209,19 +259,42 @@ public:
 
 	int getMinutes()
 	{
-		double pos = m_isStreaming ? DashAudio_GetMusicPosition() : 0.0;
+		double pos = IsCdUrl(m_loadedUrl) ? CdAudio_GetPosition()
+		                                  : (m_isStreaming ? DashAudio_GetMusicPosition() : 0.0);
 		return (int)(pos / 60.0);
 	}
 
 	int getSeconds()
 	{
-		double pos = m_isStreaming ? DashAudio_GetMusicPosition() : 0.0;
+		double pos = IsCdUrl(m_loadedUrl) ? CdAudio_GetPosition()
+		                                  : (m_isStreaming ? DashAudio_GetMusicPosition() : 0.0);
 		return ((int)pos) % 60;
 	}
 
 	void Advance(float nSeconds)
 	{
 		CTimeDepNode::Advance(nSeconds);
+
+		if (m_transportMode == 1 && IsCdUrl(m_loadedUrl)) {
+			CdAudio_Update();
+
+			if (m_sendProgress) {
+				int track = atoi(m_loadedUrl + 3);
+				int dur = CdAudio_GetTrackDurationSeconds(track);
+				double pos = CdAudio_GetPosition();
+				m_progress = (dur > 0) ? (float)(pos / dur) : 0.0f;
+				CallFunction(this, _T("OnProgressChanged"));
+			}
+
+			if (!CdAudio_IsPlaying() && !CdAudio_IsPaused()) {
+				m_transportMode = 0;
+				m_isActive = false;
+				m_progress = 1.0f;
+				CallFunction(this, _T("OnEndOfAudio"));
+				CallFunction(this, _T("OnTransportModeChanged"));
+			}
+			return;
+		}
 
 		if (m_transportMode == 1) {
 			if (m_isStreaming) {
@@ -1073,7 +1146,7 @@ class CDiscDrive : public CNode
 public:
 	static CDiscDrive* s_instance;
 
-	CDiscDrive() : m_discType(NULL), m_locked(false) {
+	CDiscDrive() : m_discType(NULL), m_locked(false), m_pollTimer(2.0f) {
 		m_discType = strdup("none");
 		s_instance = this;
 	}
@@ -1082,11 +1155,55 @@ public:
 	DECLARE_NODE_PROPS()
 	DECLARE_NODE_FUNCTIONS()
 	TCHAR* m_discType;
-	bool m_locked;
+	bool   m_locked;
+	float  m_pollTimer;
 
-	int getTrackCount() { return 0; }
-	CStrObject* FormatTotalTime() { return new CStrObject(_T("0:00")); }
-	CStrObject* FormatTrackTime(int) { return new CStrObject(_T("0:00")); }
+	void Advance(float nSeconds) {
+		CNode::Advance(nSeconds);
+		m_pollTimer += nSeconds;
+		if (m_pollTimer < 2.0f) return;
+		m_pollTimer = 0.0f;
+
+		CdAudio_Poll();
+
+		const char* newType;
+		switch (CdAudio_GetDiscType()) {
+			case CD_AUDIO: newType = "Audio"; break;
+			default:       newType = "none";  break;
+		}
+
+		if (m_discType && strcmp(m_discType, newType) == 0) return;
+
+		bool wasNone = !m_discType || strcmp(m_discType, "none") == 0;
+		bool isNone  = strcmp(newType, "none") == 0;
+
+		free(m_discType);
+		m_discType = strdup(newType);
+
+		if (!m_locked) {
+			if (!isNone && wasNone)
+				CallFunction(this, "OnDiscInserted");
+			else if (isNone && !wasNone)
+				CallFunction(this, "OnDiscRemoved");
+		}
+	}
+
+	int getTrackCount() { return CdAudio_GetTrackCount(); }
+
+	CStrObject* FormatTotalTime() {
+		int total = CdAudio_GetTotalDurationSeconds();
+		char buf[16];
+		snprintf(buf, sizeof(buf), "%d:%02d", total / 60, total % 60);
+		return new CStrObject(buf);
+	}
+
+	CStrObject* FormatTrackTime(int track) {
+		int dur = CdAudio_GetTrackDurationSeconds(track);
+		char buf[16];
+		snprintf(buf, sizeof(buf), "%d:%02d", dur / 60, dur % 60);
+		return new CStrObject(buf);
+	}
+
 	void LaunchDisc() {
 		// On real Xbox this reboots into the DVD player app.
 		// On desktop, we intercept and just start the DVD inline player.
@@ -1099,45 +1216,44 @@ public:
 	void OpenTray() {}
 	void CloseTray() {}
 	CStrObject* getArtist() { return new CStrObject; }
-	CStrObject* getTitle() { return new CStrObject; }
+	CStrObject* getTitle()  { return new CStrObject; }
 	CStrObject* getTrackName(int) { return new CStrObject; }
 };
 
 CDiscDrive* CDiscDrive::s_instance = nullptr;
 IMPLEMENT_NODE("DiscDrive", CDiscDrive, CNode)
 
-// Set the disc type from outside the XAP (triggers OnDiscInserted/OnDiscRemoved callbacks)
-// Mirrors the Xbox disc.cpp approach: set m_discType, then CallFunction("OnDiscInserted")
+// Set the disc type from outside the XAP (used by menu_bar for simulation).
+// Video: directly invokes StartDVDPlayer (bypasses XAP, matches prior desktop behaviour).
+// Audio: fires the normal OnDiscInserted callback so the XAP music screen handles it.
+// none : fires OnDiscRemoved (or navigates away from the DVD player if it was active).
 void DiscDrive_SetDiscType(const char* type) {
 	CDiscDrive* dd = CDiscDrive::s_instance;
 	if (!dd) return;
 
-	bool wasNone = (dd->m_discType && strcmp(dd->m_discType, "none") == 0);
-	bool isNone = (strcmp(type, "none") == 0);
+	bool wasNone = !dd->m_discType || strcmp(dd->m_discType, "none") == 0;
+	bool isNone  = strcmp(type, "none") == 0;
 
-	// Update the property
 	if (dd->m_discType) free(dd->m_discType);
 	dd->m_discType = strdup(type);
 
-	// Call the XAP callback directly, just like the Xbox kernel does
-	if (!isNone) {
-		// Skip the Xbox reboot-to-DVD flow entirely.
-		// Just make the DVD player inline visible directly.
+	if (isNone) {
+		if (!wasNone) {
+			CObject* pRoot = (CObject*)g_pObject;
+			if (pRoot) CallFunction(pRoot, "GoToLauncher");
+			fprintf(stderr, "[DiscDrive] discType='none', navigated to launcher\n");
+		}
+	} else if (strcmp(type, "Video") == 0) {
 		CObject* pRoot = (CObject*)g_pObject;
 		if (pRoot) {
 			CallFunction(pRoot, "StartDVDPlayer");
-			fprintf(stderr, "[DiscDrive] discType='%s', called StartDVDPlayer directly\n", type);
+			fprintf(stderr, "[DiscDrive] discType='Video', called StartDVDPlayer\n");
 		}
-	} else if (isNone && !wasNone) {
-		// Skip the Xbox OnDiscRemoved which tries to reboot via theLauncherLevel.
-		// Instead, just hide the DVD player inline and go to the launcher menu.
-		CObject* pRoot = (CObject*)g_pObject;
-		if (pRoot) {
-			// The XAP hides the DVD player by setting theDVDPlayerInline.visible = false
-			// and navigating. We call GoToLauncher which goes to the harddrive menu.
-			CallFunction(pRoot, "GoToLauncher");
-		}
-		fprintf(stderr, "[DiscDrive] discType='none', navigated to launcher\n");
+	} else {
+		// Audio CD (or anything else): let the XAP script decide via OnDiscInserted
+		if (!dd->m_locked)
+			CallFunction(dd, "OnDiscInserted");
+		fprintf(stderr, "[DiscDrive] discType='%s', fired OnDiscInserted\n", type);
 	}
 }
 

--- a/theseus/desktop/desktop_nodes.cpp
+++ b/theseus/desktop/desktop_nodes.cpp
@@ -141,6 +141,7 @@ public:
 		if (m_transportMode == 2) {
 			if (IsCdUrl(m_loadedUrl)) {
 				CdAudio_Resume();
+				DashAudio_MuteAll();
 			} else if (m_isStreaming) {
 				DashAudio_ResumeMusic();
 			} else if (m_channel >= 0) {
@@ -158,6 +159,7 @@ public:
 			int track = atoi(m_loadedUrl + 3);
 			if (track < 1) track = 1;
 			if (CdAudio_Play(track)) {
+				DashAudio_MuteAll();
 				m_transportMode = 1;
 				m_isActive = true;
 				CallFunction(this, _T("onPlay"));
@@ -195,6 +197,7 @@ public:
 	{
 		if (IsCdUrl(m_loadedUrl)) {
 			CdAudio_Stop();
+			DashAudio_UnmuteAll();
 			m_transportMode = 0;
 			m_isActive = false;
 			m_progress = 0.0f;
@@ -224,9 +227,14 @@ public:
 	{
 		if (m_transportMode == 2) {
 			// Toggle: resume if already paused
-			if (IsCdUrl(m_loadedUrl))      CdAudio_Resume();
-			else if (m_isStreaming)         DashAudio_ResumeMusic();
-			else if (m_channel >= 0)        DashAudio_ResumeChannel(m_channel);
+			if (IsCdUrl(m_loadedUrl)) {
+				CdAudio_Resume();
+				DashAudio_MuteAll();
+			} else if (m_isStreaming) {
+				DashAudio_ResumeMusic();
+			} else if (m_channel >= 0) {
+				DashAudio_ResumeChannel(m_channel);
+			}
 			m_transportMode = 1;
 			CallFunction(this, _T("onPlay"));
 			CallFunction(this, _T("OnTransportModeChanged"));
@@ -237,6 +245,7 @@ public:
 
 		if (IsCdUrl(m_loadedUrl)) {
 			CdAudio_Pause();
+			DashAudio_UnmuteAll();
 			m_transportMode = 2;
 			CallFunction(this, _T("onPause"));
 			CallFunction(this, _T("OnTransportModeChanged"));
@@ -313,6 +322,7 @@ public:
 			}
 
 			if (!CdAudio_IsPlaying() && !CdAudio_IsPaused()) {
+				DashAudio_UnmuteAll();
 				m_transportMode = 0;
 				m_isActive = false;
 				m_progress = 1.0f;

--- a/theseus/desktop/desktop_nodes.cpp
+++ b/theseus/desktop/desktop_nodes.cpp
@@ -137,6 +137,21 @@ public:
 
 	void Play()
 	{
+		// If paused, resume from current position rather than restart.
+		if (m_transportMode == 2) {
+			if (IsCdUrl(m_loadedUrl)) {
+				CdAudio_Resume();
+			} else if (m_isStreaming) {
+				DashAudio_ResumeMusic();
+			} else if (m_channel >= 0) {
+				DashAudio_ResumeChannel(m_channel);
+			}
+			m_transportMode = 1;
+			CallFunction(this, _T("onPlay"));
+			CallFunction(this, _T("OnTransportModeChanged"));
+			return;
+		}
+
 		LoadIfNeeded();
 
 		if (IsCdUrl(m_loadedUrl)) {
@@ -207,6 +222,17 @@ public:
 
 	void Pause()
 	{
+		if (m_transportMode == 2) {
+			// Toggle: resume if already paused
+			if (IsCdUrl(m_loadedUrl))      CdAudio_Resume();
+			else if (m_isStreaming)         DashAudio_ResumeMusic();
+			else if (m_channel >= 0)        DashAudio_ResumeChannel(m_channel);
+			m_transportMode = 1;
+			CallFunction(this, _T("onPlay"));
+			CallFunction(this, _T("OnTransportModeChanged"));
+			return;
+		}
+
 		if (m_transportMode != 1) return;
 
 		if (IsCdUrl(m_loadedUrl)) {
@@ -1198,7 +1224,7 @@ public:
 	}
 
 	CStrObject* FormatTrackTime(int track) {
-		int dur = CdAudio_GetTrackDurationSeconds(track);
+		int dur = CdAudio_GetTrackDurationSeconds(track + 1);  // script passes 0-based index
 		char buf[16];
 		snprintf(buf, sizeof(buf), "%d:%02d", dur / 60, dur % 60);
 		return new CStrObject(buf);

--- a/theseus/desktop/sdl_main.cpp
+++ b/theseus/desktop/sdl_main.cpp
@@ -574,9 +574,18 @@ int main(int argc, char* argv[]) {
 #endif
     }
 
-#if !defined(__SANITIZE_ADDRESS__)
-    // ASan installs its own SIGSEGV/SIGBUS handlers that print rich
-    // reports with allocation/deallocation history; ours would eat them.
+
+    // This fixes compilation so it works for both GCC and clang
+#if defined(__SANITIZE_ADDRESS__)
+    #define ASAN_ACTIVE 1
+#elif defined(__has_feature)
+    #if __has_feature(address_sanitizer)
+        #define ASAN_ACTIVE 1
+    #endif
+#endif
+
+#if !defined(ASAN_ACTIVE)
+    // ASan installs its own SIGSEGV/SIGBUS handlers; ours would eat them.
     // Skip our handler entirely on asan builds.
 #  ifdef _WIN32
     SetUnhandledExceptionFilter(WindowsCrashHandler);
@@ -586,6 +595,8 @@ int main(int argc, char* argv[]) {
 #  endif
     signal(SIGABRT, crash_handler);
 #endif
+
+#undef ASAN_ACTIVE // Clean up
 
     // Initialize SDL
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_GAMECONTROLLER) < 0) {

--- a/theseus/desktop/sdl_main.cpp
+++ b/theseus/desktop/sdl_main.cpp
@@ -574,7 +574,7 @@ int main(int argc, char* argv[]) {
 #endif
     }
 
-#if !defined(__has_feature) || !__has_feature(address_sanitizer)
+#if !defined(__SANITIZE_ADDRESS__)
     // ASan installs its own SIGSEGV/SIGBUS handlers that print rich
     // reports with allocation/deallocation history; ours would eat them.
     // Skip our handler entirely on asan builds.

--- a/theseus/engine/runner.h
+++ b/theseus/engine/runner.h
@@ -54,13 +54,11 @@ public:
 class CMemberFunctionObject : public CObject
 {
 public:
-	CMemberFunctionObject(CInstance* pInstance, CFunction* pFunction);
+	CMemberFunctionObject(CObject* pOwner, CFunction* pFunction);
 	~CMemberFunctionObject();
-
-	CInstance* m_owner;
-	CFunction* m_function;
-
 	CObject* Deref();
+	CObject* m_owner;
+	CFunction* m_function;
 };
 
 

--- a/theseus/render/node_system.cpp
+++ b/theseus/render/node_system.cpp
@@ -534,6 +534,12 @@ CObject* CObject::Dot(CObject* pObj)
 		CObject* pObject = GetMember(pVar->m_text, pVar->m_length);
 		if (pObject != NULL)
 		{
+			if (pObject->m_obj == objFunction)
+			{
+				// Wrap in CMemberFunctionObject so opCall sets m_self correctly.
+				AddRef();
+				return new CMemberFunctionObject(this, (CFunction*)pObject);
+			}
 			pObject->AddRef();
 			return pObject;
 		}

--- a/theseus/shared/xap_vm.cpp
+++ b/theseus/shared/xap_vm.cpp
@@ -254,10 +254,10 @@ void CMemberVarObject::Assign(CObject* pNewObject)
 
 // CMemberFunctionObject: reference to a scripted member function.
 
-CMemberFunctionObject::CMemberFunctionObject(CInstance* pInstance, CFunction* pFunction)
+CMemberFunctionObject::CMemberFunctionObject(CObject* pOwner, CFunction* pFunction)
 {
 	m_obj = objMemberFunction;
-	m_owner = pInstance;
+	m_owner = pOwner;
 	m_function = pFunction;
 }
 
@@ -265,7 +265,7 @@ CMemberFunctionObject::~CMemberFunctionObject() {}
 
 CObject* CMemberFunctionObject::Deref()
 {
-	CRunner runner(m_owner);
+	CRunner runner(m_owner);   // CObject* — no cast needed now
 	runner.SetFunc(m_function);
 	CObject* pObject = runner.Run();
 	Release();
@@ -1095,6 +1095,8 @@ bool CRunner::Step(CObject** ppRetObj)
 			ASSERT(m_sp >= (UINT)(nParam + 1));
 			CObject* pFun = (CVarObject*)m_stack[m_sp - (nParam + 1)];
 			CObject** rgparam = &m_stack[m_sp - nParam];
+
+			if (pFun == NULL) { Error(_T("call on null")); return NULL; }
 
 			if (pFun->m_obj == objFunctionRef)
 			{


### PR DESCRIPTION
This PR adds SDL or libmpv based CD Playback to UIX-Desktop. When compiling it will use libmpv first if it is found, otherwise will use SDL or fall back to no CD functionality if it's unavailable.

It also fixes a couple of other issues I found regarding unpausing music/soundtracks being non-functional, as well as fix some compilation issues when cross-compiling for Windows from Ubuntu 24, namely the location of a library being different on Linux vs macOS and the difference between GCC and clang in handling ASan checks so both will work.

I've only tested this on WSL Ubuntu 24 cross-compiling for Windows, as far as I'm aware it should work on Linux too and there's some code to handle checking Linux optical drive paths (like /dev/sr0, /dev/cdrom etc) but I have not tried it. I have absolutely no idea if this will work on macOS/other operating systems, but if it can't find a backend to use it should just go back to no CD audio playback like how it does currently in the public build.