### PR TITLE
Automatic UIX Desktop release action

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,301 @@
+name: UIX Theseus builder
+permissions:
+  contents: read 
+on:
+# Manual trigger, no automatic trigger here.
+  workflow_dispatch
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+    name: Build UIX Desktop (Linux build)
+    container: ghcr.io/pkgforge-dev/archlinux:latest
+    steps:
+      - name: Chekout repository
+        uses: actions/checkout@v6
+      - name: Install Dependencies
+        run: |
+          pacman -Syu --noconfirm \
+          make     \
+          base-devel \
+          libdecor  \
+          sdl2      \
+          sdl2_mixer
+      - name: Build UIX Desktop (Linux)
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          make DESKTOP_DIR=$GITHUB_WORKSPACE/UIX-Desktop desktop
+      - name: Pack UIX-Desktop
+        run: | 
+          echo "Cleaning up build"
+          cd $GITHUB_WORKSPACE/UIX-Desktop
+          rm -rf ./desktop
+          rm -rf ./engine
+          rm -rf ./render
+          rm -rf ./shared
+          rm -rf ./xbox
+          echo "Zipping up and setting as artifact"
+          cd $GITHUB_WORKSPACE
+          tar -czvf "UIX-Desktop-Linux.tar.gz" UIX-Desktop
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: UIX-Desktop-Linux
+          path: "./UIX-Desktop-Linux.tar.gz"
+          archive: false
+
+  macos-arm-build: 
+    name: Build UIX Desktop (MacOS Arm build)
+    runs-on: macos-26
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v6
+        - name: Install Dependencies
+          run: |
+            brew install sdl2 sdl2_mixer
+        - name: Build UIX Desktop (MacOS Arm)
+          run: |
+            cd $GITHUB_WORKSPACE/build
+            make desktop
+        - name: Pack UIX-Desktop
+          run: |
+            echo "Cleaning up build"
+            cd /Users/runner/builds/theseus/desktop
+            rm -rf ./desktop
+            rm -rf ./engine
+            rm -rf ./render
+            rm -rf ./shared
+            rm -rf ./xbox
+
+            echo "Zipping up and setting as artifact"
+            mv /Users/runner/builds/theseus/desktop $GITHUB_WORKSPACE/UIX-Desktop
+            cd $GITHUB_WORKSPACE
+            zip -r "UIX-Desktop-MacOS.zip" UIX-Desktop
+        - name: Upload artifact
+          uses: actions/upload-artifact@v7
+          with:
+            name: UIX-Desktop-MacOS
+            path: "./UIX-Desktop-MacOS.zip"
+            archive: false
+          
+  macos-intel-build:
+    runs-on: macos-26-intel
+    name: Build UIX Desktop (MacOS Intel build)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Dependencies
+        run: |
+          brew install sdl2 sdl2_mixer
+      - name: Build UIX Desktop (MacOS Intel)
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          make desktop
+      - name: Pack UIX-Desktop
+        run: |
+          echo "Cleaning up build"
+            cd /Users/runner/builds/theseus/desktop
+            rm -rf ./desktop
+            rm -rf ./engine
+            rm -rf ./render
+            rm -rf ./shared
+            rm -rf ./xbox
+
+            echo "Zipping up and setting as artifact"
+            mv /Users/runner/builds/theseus/desktop $GITHUB_WORKSPACE/UIX-Desktop
+            cd $GITHUB_WORKSPACE
+            zip -r "UIX-Desktop-MacOS-Intel.zip" UIX-Desktop
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: UIX-Desktop-MacOS-Intel
+          path: "./UIX-Desktop-MacOS-Intel.zip"
+          archive: false
+
+  windows-build:
+    runs-on: ubuntu-latest
+    name: Build UIX Desktop (Windows Build)
+    container: ghcr.io/pkgforge-dev/archlinux:latest
+    steps:
+      - name: Checkout Theseus repository
+        uses: actions/checkout@v6
+        with:
+           path: Theseus
+      - name: Checkout GLEW repository
+        uses: actions/checkout@v6
+        with:
+          repository: nigels-com/glew
+          path: glew-src
+      - name: Install Dependencies
+        run: |
+          pacman -Syu --noconfirm \
+          make     \
+          base-devel \
+          libdecor  \
+          sdl2      \
+          sdl2_mixer \
+          mingw-w64 \
+          mingw-w64-crt \
+          mingw-w64-gcc \
+          wget \
+          git \
+          mingw-w64-binutils \
+          zip
+      - name: install SDL2 mingw libs
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/sdl2-mingw
+          wget https://libsdl.org/release/SDL2-devel-2.32.10-mingw.tar.gz
+          wget https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-devel-2.8.1-mingw.tar.gz
+          echo "Extracting SDL blobs"
+          tar -x -f SDL2-devel-2.32.10-mingw.tar.gz
+          tar -x -f SDL2_mixer-devel-2.8.1-mingw.tar.gz
+          echo "Moving blobs to required dir"
+          cp -r ./SDL2-2.32.10 $GITHUB_WORKSPACE/sdl2-mingw
+          cp -r ./SDL2_mixer-2.8.1 $GITHUB_WORKSPACE/sdl2-mingw
+      - name: Installing GLEW (Building against MINGW)
+        run: |
+          cd ./glew-src/auto
+          make
+          cd $GITHUB_WORKSPACE/glew-src
+          make SYSTEM=linux-mingw64 GLEW_DEST=$GITHUB_WORKSPACE/glew-src/usr/local
+          make install DESTDIR=$GITHUB_WORKSPACE/glew-src
+          mkdir -p build-mingw
+          x86_64-w64-mingw32-gcc -DGLEW_STATIC -Iinclude -c src/glew.c -o build-mingw/glew.o
+          x86_64-w64-mingw32-ar rcs build-mingw/libglew32.a build-mingw/glew.o
+      - name: Build UIX Desktop (Windows)
+        run: |
+          ls $GITHUB_WORKSPACE/glew-src/usr/local
+          ls $GITHUB_WORKSPACE/glew-src/usr/local/include
+          ls $GITHUB_WORKSPACE/glew-src/
+          ls $GITHUB_WORKSPACE/sdl2-mingw
+          cd $GITHUB_WORKSPACE/Theseus/build
+          make desktop-win64 SDL2_MINGW_DIR=$GITHUB_WORKSPACE/sdl2-mingw GLEW_MINGW_DIR=$GITHUB_WORKSPACE/glew-src
+      - name: Pack UIX-Desktop
+        run: | 
+          mv /github/home/builds/theseus/desktop-win64 $GITHUB_WORKSPACE/UIX-Desktop
+          echo "Cleaning up build"
+          cd $GITHUB_WORKSPACE/UIX-Desktop
+          rm -rf ./desktop
+          rm -rf ./engine
+          rm -rf ./render
+          rm -rf ./shared
+          rm -rf ./xbox
+          echo "Zipping up and setting as artifact"
+          cd $GITHUB_WORKSPACE
+          zip -r "UIX-Desktop-Win.zip" UIX-Desktop
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: UIX-Desktop-Win
+          path: "./UIX-Desktop-Win.zip"
+          archive: false
+
+
+#  xbox-retail-build:
+#     name: Build UIX Theseus (Retail build)
+#     runs-on: macos-26
+#     steps:
+#       - name: Checkout Theseus repository
+#         uses: actions/checkout@v6
+#         with:
+#           path: Theseus
+#       - name: Checkout OXDK repository
+#         uses: actions/checkout@v6
+#         with:
+#           repository: MrMilenko/OXDK
+#           path: OXDK
+#       - name: Install Dependencies
+#         run: |
+#           brew install llvm
+#       - name: Build OXDK
+#         run: | 
+#           cd ./OXDK
+#           echo "Builder Stubbed. Implement later."
+#       - name: build Theseus
+#         run: |
+#           CD ./Theseus
+#           echo "Builder Stubbed. Implement later."
+#      - name: Upload artifact
+#        uses: actions/upload-artifact@v7
+#        with:
+#          name: UIX-Theseus-Retail
+#          path: "./UIX-Theseus-Retail.zip"
+#          archive: false
+
+#  xbox-debug-build:
+#     name: Build UIX Theseus (debug build)
+#     runs-on: macos-26
+#     steps:
+#       - name: Checkout Theseus repository
+#         uses: actions/checkout@v6
+#         with:
+#           path: Theseus
+#       - name: Checkout OXDK repository
+#         uses: actions/checkout@v6
+#         with:
+#           repository: MrMilenko/OXDK
+#           path: OXDK
+#       - name: Install Dependencies
+#         run: |
+#           brew install llvm
+#       - name: Build OXDK
+#         run: | 
+#           cd ./OXDK
+#           echo "Builder Stubbed. Implement later."
+#       - name: build Theseus
+#         run: |
+#           CD ./Theseus
+#           echo "Builder Stubbed. Implement later."
+#      - name: Upload artifact
+#        uses: actions/upload-artifact@v7
+#        with:
+#          name: UIX-Theseus-Retail
+#          path: "./UIX-Theseus-Retail.zip"
+#          archive: false
+
+
+  release:
+    needs: [linux-build, macos-intel-build, macos-arm-build, windows-build]
+    runs-on: ubuntu-latest
+    permissions:
+       contents: write
+       actions: read
+    steps:
+       - name: Download build artifacts
+         uses: actions/download-artifact@v8
+         with:
+            path: 'outputs/'
+            skip-decompress: 'true'
+       - name: Create release note
+         env:
+           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           GH_REPO: ${{ github.repository }}
+         run: |
+           set -euo pipefail
+           cd $GITHUB_WORKSPACE
+           REPO="$GH_REPO"
+           TS="$(date +'%Y-%m-%d')"
+           NOTES_FILE="$GITHUB_WORKSPACE/release-notes.md"
+           TITLE="UIX Desktop Builds $TS"
+           cat > "$NOTES_FILE" <<'EOF'
+           # UIX Desktop builds
+
+           Built from the latest Theseus commits. (as of $TS)
+
+           ## Versions
+           - `UIX-Desktop-Win` - Reverse Engineered Xbox Dashboard (Windows Build)
+           - `UIX-Desktop-MacOS` - Reverse Engineered Xbox Dashboard (MacOS Arm build)
+           - `UIX-Desktop-MacOS-Intel` - Reverse Engineered Xbox Dashboard (MacOS Intel build)
+           - `UIX-Desktop-Linux` - Reverse Engineered Xbox Dashboard (Linux)
+           EOF
+           if gh release view "$TS" --repo "$REPO" >/dev/null 2>&1; then
+           echo "Release $TS already exists; updating title/notes."
+           gh release edit "$TS" --repo "$REPO" --title "$TITLE" --notes-file "$NOTES_FILE"
+           else
+           echo "Creating new release $TS."
+           gh release create "$TS" --repo "$REPO" --title "$TITLE" --notes-file "$NOTES_FILE" --target "$GITHUB_SHA"
+           fi
+           echo "Uploading artifacts to $TS (clobber if they already exist)..."
+           ls -la outputs || true
+           cd ./outputs
+           gh release upload "$TS" --repo "$REPO" */* --clobber

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -20,7 +20,8 @@ jobs:
           base-devel \
           libdecor  \
           sdl2      \
-          sdl2_mixer
+          sdl2_mixer \
+          mpv
       - name: Build UIX Desktop (Linux)
         run: |
           cd $GITHUB_WORKSPACE/build

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -280,8 +280,8 @@ jobs:
            cat > "$NOTES_FILE" <<'EOF'
            # UIX Desktop builds
 
-           Built from the latest Theseus commits. (as of $TS)
-
+           Built from the latest Theseus commits.
+           
            ## Versions
            - `UIX-Desktop-Win` - Reverse Engineered Xbox Dashboard (Windows Build)
            - `UIX-Desktop-MacOS` - Reverse Engineered Xbox Dashboard (MacOS Arm build)

--- a/build/Makefile
+++ b/build/Makefile
@@ -445,7 +445,7 @@ clean:
 #   - SDL2_mixer (brew install sdl2_mixer / apt install libsdl2-mixer-dev)
 #   - OpenGL headers (system-provided)
 
-DESKTOP_DIR    = $(BUILDS_ROOT)/desktop
+DESKTOP_DIR    ?= $(BUILDS_ROOT)/desktop
 DESKTOP_TARGET = $(DESKTOP_DIR)/theseus
 
 # Detect platform

--- a/theseus/desktop/cdaudio.cpp
+++ b/theseus/desktop/cdaudio.cpp
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-
+#include <climits>
 #define MAX_CDTRACKS 99
 
 // ============================================================================


### PR DESCRIPTION
This PR enables a github action which automatically builds the latest commit (at time of running this action) of Theseus to build UIX Desktop for all main supported platforms.
Windows, MacOS (Arm), MacOS (Intel) and Linux.

Further builds can be added later (Linux ARM64)

This has been tested and is working on my fork.