### PR TITLE
vsync, libmpv, windows fixes, testing cleanup

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -835,7 +835,7 @@ WIN64_LDFLAGS = \
 	-lglew32 \
 	-lmpv -lcurl \
 	-lopengl32 -lgdi32 -limm32 -lole32 -loleaut32 -lsetupapi -lversion -lwinmm -luuid \
-	-lws2_32 -ldbghelp
+	-lws2_32 -ldbghelp -lavrt -ldwmapi
 
 # Same source list as desktop -- the compiler reads the same files.
 WIN64_OBJS = $(patsubst $(THESEUS_SRC)/%.cpp,$(WIN64_DIR)/%.o,$(DESKTOP_ALL_SRCS))

--- a/theseus/desktop/dashinit.cpp
+++ b/theseus/desktop/dashinit.cpp
@@ -140,18 +140,7 @@ void DashInit()
 	// Initialize skin system
 	InitSkin();
 
-	// Init networking
-	if (net::init())
-	{
-		IN_ADDR addr = {net::getAddress()};
-		char ipStr[16];
-		XNetInAddrToString(addr, ipStr, sizeof(ipStr));
-		TRACE("Network Up. IP: %S\n", ipStr);
-	}
-	else
-	{
-		TRACE("Network failed to initialize.\n");
-	}
+	// No net::init() on desktop; FTP/IP belong to the Xbox path.
 
 	// Start Discord relay if enabled
 	InitDiscord();

--- a/theseus/desktop/media_player.cpp
+++ b/theseus/desktop/media_player.cpp
@@ -325,6 +325,12 @@ bool   MediaPlayer_HasVideo() { return s_hasVideo; }
 void MediaPlayer_Update() {
     if (!s_mpv) return;
 
+    // Natural EOF on a prior tick; tear down so we stop pumping.
+    if (s_state == MP_STOPPED) {
+        MediaPlayer_Stop();
+        return;
+    }
+
     // Process mpv events
     while (1) {
         mpv_event* event = mpv_wait_event(s_mpv, 0);

--- a/theseus/desktop/mesh.cpp
+++ b/theseus/desktop/mesh.cpp
@@ -147,10 +147,7 @@ bool CMesh::Load(const TCHAR *szFilePath)
     {
         hFile = TheseusCreateFile(szFilePath, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
         if (hFile == INVALID_HANDLE_VALUE)
-        {
-            TRACE("\001[Mesh] Cannot load MeshNode: %s\n", szFilePath);
             return false;
-        }
 
     }
 

--- a/theseus/desktop/sdl_main.cpp
+++ b/theseus/desktop/sdl_main.cpp
@@ -33,6 +33,8 @@
 #include <direct.h>
 #include <process.h>
 #include <dbghelp.h>
+#include <avrt.h>
+#include <dwmapi.h>
 #pragma comment(lib, "dbghelp.lib")
 
 // Watchdog: dumps main thread stack to hang_dump.txt after 10s of detected hang
@@ -710,6 +712,27 @@ int main(int argc, char* argv[]) {
         freopen("CONOUT$", "w", stdout);
         freopen("CONOUT$", "w", stderr);
         freopen("CONIN$", "r", stdin);
+    }
+
+    //Milenko-Testing: I don't run windows, i googled this. don't know if it will work as intended.
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+    DwmEnableMMCSS(TRUE);
+    {
+        DWORD taskIdx = 0;
+        AvSetMmThreadCharacteristicsW(L"Games", &taskIdx);
+    }
+    typedef BOOL (WINAPI *SetProcessInfoFn)(HANDLE, PROCESS_INFORMATION_CLASS, LPVOID, DWORD);
+    HMODULE hKernel = GetModuleHandleA("kernel32.dll");
+    if (hKernel) {
+        SetProcessInfoFn pSetProcessInformation =
+            (SetProcessInfoFn)GetProcAddress(hKernel, "SetProcessInformation");
+        if (pSetProcessInformation) {
+            PROCESS_POWER_THROTTLING_STATE pt = {0};
+            pt.Version = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+            pt.ControlMask = PROCESS_POWER_THROTTLING_EXECUTION_SPEED;
+            pt.StateMask = 0; // 0 == opt out of throttling
+            pSetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling, &pt, sizeof(pt));
+        }
     }
 #endif
 

--- a/theseus/desktop/sdl_main.cpp
+++ b/theseus/desktop/sdl_main.cpp
@@ -835,8 +835,9 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // Enable vsync
-    SDL_GL_SetSwapInterval(1);
+    // Adaptive vsync; fall back to hard vsync if unsupported.
+    if (SDL_GL_SetSwapInterval(-1) != 0)
+        SDL_GL_SetSwapInterval(1);
 
     fprintf(stdout, "UIX Desktop - SDL/OpenGL Preview Tool\n");
     fprintf(stdout, "OpenGL: %s\n", glGetString(GL_VERSION));
@@ -1370,7 +1371,8 @@ int main(int argc, char* argv[]) {
                 g_pGLContext = SDL_GL_CreateContext(g_pSDLWindow);
                 g_msaaSamples = 0;
             }
-            SDL_GL_SetSwapInterval(1);
+            if (SDL_GL_SetSwapInterval(-1) != 0)
+                SDL_GL_SetSwapInterval(1);
 
             // Enable/disable MSAA
             if (g_msaaSamples > 0) glEnable(GL_MULTISAMPLE);


### PR DESCRIPTION
googled a few windows hints for things that may be throttling windows, found a carry over bug from porting to desktops that basically throttled the entire dashboard because we hard lock it over there. mpv was running refreshes with no media.

Who would've thought me being cheap and not having a high refresh monitor would be this obvious?

