### PR TITLE
title_maker: stop popping cmd.exe windows on steam import. system("cu…

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -649,6 +649,7 @@ DESKTOP_SRCS_PLATFORM = \
 	$(THESEUS_SRC)/desktop/boot_anim.cpp \
 	$(THESEUS_SRC)/desktop/media_ui.cpp \
 	$(THESEUS_SRC)/desktop/tmdb.cpp \
+	$(THESEUS_SRC)/desktop/http_util.cpp \
 	$(THESEUS_SRC)/desktop/xiso.cpp
 
 # ImGui sources

--- a/theseus/desktop/http_util.cpp
+++ b/theseus/desktop/http_util.cpp
@@ -1,0 +1,50 @@
+#include "http_util.h"
+#include <curl/curl.h>
+#include <stdio.h>
+#include <mutex>
+
+static std::once_flag s_initOnce;
+static void EnsureGlobalInit() {
+    std::call_once(s_initOnce, []{ curl_global_init(CURL_GLOBAL_DEFAULT); });
+}
+
+static void ApplyCommonOpts(CURL* h, const char* url) {
+    curl_easy_setopt(h, CURLOPT_URL, url);
+    curl_easy_setopt(h, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(h, CURLOPT_TIMEOUT, 10L);
+    curl_easy_setopt(h, CURLOPT_USERAGENT, "Theseus-Dashboard/1.0");
+    curl_easy_setopt(h, CURLOPT_FAILONERROR, 1L);
+}
+
+static size_t WriteToString(void* ptr, size_t size, size_t nmemb, void* user) {
+    ((std::string*)user)->append((char*)ptr, size * nmemb);
+    return size * nmemb;
+}
+
+std::string Http_GetToString(const std::string& url) {
+    EnsureGlobalInit();
+    std::string out;
+    CURL* h = curl_easy_init();
+    if (!h) return out;
+    ApplyCommonOpts(h, url.c_str());
+    curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, WriteToString);
+    curl_easy_setopt(h, CURLOPT_WRITEDATA, &out);
+    if (curl_easy_perform(h) != CURLE_OK) out.clear();
+    curl_easy_cleanup(h);
+    return out;
+}
+
+bool Http_GetToFile(const std::string& url, const std::string& outPath) {
+    EnsureGlobalInit();
+    FILE* fp = fopen(outPath.c_str(), "wb");
+    if (!fp) return false;
+    CURL* h = curl_easy_init();
+    if (!h) { fclose(fp); remove(outPath.c_str()); return false; }
+    ApplyCommonOpts(h, url.c_str());
+    curl_easy_setopt(h, CURLOPT_WRITEDATA, fp);
+    CURLcode rc = curl_easy_perform(h);
+    curl_easy_cleanup(h);
+    fclose(fp);
+    if (rc != CURLE_OK) { remove(outPath.c_str()); return false; }
+    return true;
+}

--- a/theseus/desktop/http_util.h
+++ b/theseus/desktop/http_util.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Shared libcurl wrappers. One boilerplate, two output flavors.
+
+#include <string>
+
+// GET url into a string. Empty on failure or non-2xx.
+std::string Http_GetToString(const std::string& url);
+
+// GET url straight to disk. Removes partial file on failure.
+bool Http_GetToFile(const std::string& url, const std::string& outPath);

--- a/theseus/desktop/title_maker.cpp
+++ b/theseus/desktop/title_maker.cpp
@@ -12,6 +12,7 @@
 #include "imgui.h"
 #include "imfilebrowser.h"
 #include "stb_image.h"
+#include "http_util.h"
 #include <sys/stat.h>
 #include <algorithm>
 #include <string>
@@ -967,7 +968,6 @@ void RenderTitleMaker() {
                 snprintf(iconPath, sizeof(iconPath), "%s/%s.jpg", VGAMES_ICONS, titleID);
                 struct stat ist;
                 if (stat(iconPath, &ist) != 0) {
-                    char curlCmd[1024];
                     char tmpPath[512];
                     bool gotIcon = false;
 
@@ -979,31 +979,30 @@ void RenderTitleMaker() {
                     };
                     for (int u = 0; tryUrls[u] && !gotIcon; u++) {
                         bool isPng = strstr(tryUrls[u], ".png") != NULL;
+                        char url[512];
                         snprintf(tmpPath, sizeof(tmpPath), "%s/%s_tmp%s", VGAMES_ICONS, titleID, isPng ? ".png" : ".jpg");
-                        snprintf(curlCmd, sizeof(curlCmd),
-                            "curl -sL -o \"%s\" \"https://cdn.akamai.steamstatic.com/steam/apps/%d/%s\" 2>/dev/null",
-                            tmpPath, games[i].appid, tryUrls[u]);
-                        if (system(curlCmd) == 0 && stat(tmpPath, &ist) == 0 && ist.st_size > 1000) {
+                        snprintf(url, sizeof(url),
+                            "https://cdn.akamai.steamstatic.com/steam/apps/%d/%s",
+                            games[i].appid, tryUrls[u]);
+                        if (Http_GetToFile(url, tmpPath) && stat(tmpPath, &ist) == 0 && ist.st_size > 1000) {
 #ifdef __APPLE__
-                            // macOS: sips ships with the OS, resize to 128x128.
-                            snprintf(curlCmd, sizeof(curlCmd),
+                            // sips ships with macOS, resize to 128x128.
+                            char cmd[1024];
+                            snprintf(cmd, sizeof(cmd),
                                 "sips -z 128 128 -s format jpeg \"%s\" --out \"%s\" >/dev/null 2>&1", tmpPath, iconPath);
+                            bool resizeOk = (system(cmd) == 0);
 #elif defined(_WIN32)
-                            // Windows: no ImageMagick on stock installs, and
-                            // bundling it for one resize call isn't worth the
-                            // weight. Steam CDN's library_icon.* is already
-                            // close to 128x128, and the dashboard scales at
-                            // render time anyway, so just copy as-is.
-                            snprintf(curlCmd, sizeof(curlCmd),
-                                "copy /Y \"%s\" \"%s\" >nul 2>&1", tmpPath, iconPath);
-                            for (char* p = curlCmd; *p; p++)
-                                if (*p == '/') *p = '\\';
+                            // No resize. CDN art is close to 128 and we scale at draw.
+                            // stdio copy avoids a cmd.exe console flash.
+                            bool resizeOk = TM_CopyFile(tmpPath, iconPath);
 #else
-                            // Linux: convert if installed, else fall back to cp.
-                            snprintf(curlCmd, sizeof(curlCmd),
+                            // convert if installed, else cp.
+                            char cmd[1024];
+                            snprintf(cmd, sizeof(cmd),
                                 "convert \"%s\" -resize 128x128! -quality 90 \"%s\" 2>/dev/null || cp \"%s\" \"%s\"", tmpPath, iconPath, tmpPath, iconPath);
+                            bool resizeOk = (system(cmd) == 0);
 #endif
-                            if (system(curlCmd) == 0 && stat(iconPath, &ist) == 0 && ist.st_size > 500)
+                            if (resizeOk && stat(iconPath, &ist) == 0 && ist.st_size > 500)
                                 gotIcon = true;
                         }
                         remove(tmpPath);

--- a/theseus/desktop/tmdb.cpp
+++ b/theseus/desktop/tmdb.cpp
@@ -15,7 +15,7 @@
 #include <mutex>
 #include <atomic>
 
-#include <curl/curl.h>
+#include "http_util.h"
 
 extern char g_tmdbKey[128];   // defined in sdl_main.cpp; loaded from desktop.ini
 
@@ -103,20 +103,11 @@ static void WriteFile(const std::string& path, const std::string& data)
 }
 
 
-// ============================================================================
-// HTTP (libcurl)
-// ============================================================================
-
-static size_t CurlWrite(void* ptr, size_t size, size_t nmemb, void* user)
-{
-    std::string* s = (std::string*)user;
-    s->append((char*)ptr, size * nmemb);
-    return size * nmemb;
-}
+// HTTP (via http_util)
 
 static std::string HttpGet(const std::string& url)
 {
-    // Redact api_key from the log so it doesn't leak.
+    // Redact api_key for the log.
     std::string redacted = url;
     size_t k = redacted.find("api_key=");
     if (k != std::string::npos) {
@@ -125,25 +116,8 @@ static std::string HttpGet(const std::string& url)
     }
     fprintf(stderr, "[TMDB] GET %s\n", redacted.c_str());
 
-    std::string out;
-    CURL* h = curl_easy_init();
-    if (!h) { fprintf(stderr, "[TMDB] curl_easy_init failed\n"); return out; }
-    curl_easy_setopt(h, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(h, CURLOPT_FOLLOWLOCATION, 1L);
-    curl_easy_setopt(h, CURLOPT_TIMEOUT, 10L);
-    curl_easy_setopt(h, CURLOPT_USERAGENT, "Theseus-Dashboard/1.0");
-    curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, CurlWrite);
-    curl_easy_setopt(h, CURLOPT_WRITEDATA, &out);
-    CURLcode rc = curl_easy_perform(h);
-    long httpCode = 0;
-    curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &httpCode);
-    if (rc != CURLE_OK) {
-        fprintf(stderr, "[TMDB] curl failed: %s\n", curl_easy_strerror(rc));
-        out.clear();
-    } else {
-        fprintf(stderr, "[TMDB] HTTP %ld, %zu bytes\n", httpCode, out.size());
-    }
-    curl_easy_cleanup(h);
+    std::string out = Http_GetToString(url);
+    fprintf(stderr, "[TMDB] %zu bytes\n", out.size());
     return out;
 }
 
@@ -380,14 +354,11 @@ static TmdbShow DoShowLookup(const std::string& title, const std::string& key)
 
 void TMDB_Init()
 {
-    if (s_initialized) return;
     s_initialized = true;
-    curl_global_init(CURL_GLOBAL_DEFAULT);
 }
 
 void TMDB_Shutdown()
 {
-    if (s_initialized) curl_global_cleanup();
     s_initialized = false;
 }
 


### PR DESCRIPTION
…rl ...") and the windows-only system("copy /Y ...") were both spawning cmd for every icon attempt. moved to in-process libcurl via a new http_util (also used by tmdb), windows resize step uses the existing TM_CopyFile.